### PR TITLE
10_reduceInteger/reduceInteger.cu 中的边界检查

### DIFF
--- a/10_reduceInteger/reduceInteger.cu
+++ b/10_reduceInteger/reduceInteger.cu
@@ -29,8 +29,9 @@ __global__ void warmup(int * g_idata, int * g_odata, unsigned int n)
 {
 	//set thread ID
 	unsigned int tid = threadIdx.x;
+	unsigned int idx = blockIdx.x*blockDim.x + tid;
 	//boundary check
-	if (tid >= n) return;
+	if (idx >= n) return;
 	//convert global data pointer to the 
 	int *idata = g_idata + blockIdx.x*blockDim.x;
 	//in-place reduction in global memory
@@ -52,8 +53,9 @@ __global__ void reduceNeighbored(int * g_idata,int * g_odata,unsigned int n)
 {
 	//set thread ID
 	unsigned int tid = threadIdx.x;
+	unsigned int idx = blockIdx.x*blockDim.x + tid;
 	//boundary check
-	if (tid >= n) return;
+	if (idx >= n) return;
 	//convert global data pointer to the 
 	int *idata = g_idata + blockIdx.x*blockDim.x;
 	//in-place reduction in global memory
@@ -78,7 +80,7 @@ __global__ void reduceNeighboredLess(int * g_idata,int *g_odata,unsigned int n)
 	unsigned idx = blockIdx.x*blockDim.x + threadIdx.x;
 	// convert global data pointer to the local point of this block
 	int *idata = g_idata + blockIdx.x*blockDim.x;
-	if (idx > n)
+	if (idx >= n)
 		return;
 	//in-place reduction in global memory
 	for (int stride = 1; stride < blockDim.x; stride *= 2)


### PR DESCRIPTION
应该是检查线程对应的内存地址`idx`下标是否越界。
另外假定数组大小是二的倍数的话，`reduceNeighboredLess`似乎不用检查`idx >= n`，因为循环中判断了(但是加上应该比较好？)。